### PR TITLE
chore: small change in warehouse example

### DIFF
--- a/src/main/resources/openapi/warehouse-openapi.yaml
+++ b/src/main/resources/openapi/warehouse-openapi.yaml
@@ -106,13 +106,12 @@ components:
         id:
           type: string
           example: "456"
-        
         businessUnitCode:
           type: string
-          example: "MWH.001, MWH.002"
+          example: "MWH.001"
         location:
           type: string
-          example: "ZWOLLE-001, AMSTERDAM-002"
+          example: "AMSTERDAM-001"
         capacity:
           type: integer
           example: 100


### PR DESCRIPTION
Fix the examples given for warehouse `businessUnitCode` and `location` as they were in a format that could led to think you can create multiple warehouses comma separated.