### PR TITLE
chore: get rid of quotes that does not let the user follow a link

### DIFF
--- a/assignment/BRIEFING.md
+++ b/assignment/BRIEFING.md
@@ -10,8 +10,8 @@ Basically, we have 4 entities:
 
 This system is focused on the Warehouse and Store unit creation and management. So, this is not related to the internal operations of each, but, rather, to the basic creation and management of those and some operations related to how they relate to each other.
 
-```
+
 The implementation tasks for you to tackle can be [located at CODE_ASSINGMENT.md](CODE_ASSIGNMENT.md)
-```
+
 
 Besides the regular register (CRUD) operations, a `Warehouse` also has a special operation called "replace", where the company is creating a new Warehouse in the same area of an already existent one and we will deprecate this one, re-using the Business Unit Code that identifies every Warehouse to this new one. So, when a Warehouse is replaced we basically archive the current Warehouse using the Business Unit Code provided and create the Warehouse using this same Business Unit Code. This way we have a history track of the area/business unit.


### PR DESCRIPTION
Small change in the `Briefing` file.

With this change we can see and follow the link

![image](https://github.com/user-attachments/assets/35b8d11c-1211-4681-9a37-7c11ce136893)

Without this change, this part of the file is between code quotes and there is no link available.

![image](https://github.com/user-attachments/assets/a82ab08a-498f-4554-9450-df92b847d214)
