### PR TITLE
chore: update maxCapacity at Location ZWOLLE-001

### DIFF
--- a/assignment/src/main/java/com/fulfilment/application/monolith/location/LocationGateway.java
+++ b/assignment/src/main/java/com/fulfilment/application/monolith/location/LocationGateway.java
@@ -10,7 +10,7 @@ public class LocationGateway implements LocationResolver {
   private static final List<Location> locations = new ArrayList<>();
 
   static {
-    locations.add(new Location("ZWOLLE-001", 1, 40));
+    locations.add(new Location("ZWOLLE-001", 1, 100));
     locations.add(new Location("ZWOLLE-002", 2, 50));
     locations.add(new Location("AMSTERDAM-001", 5, 100));
     locations.add(new Location("AMSTERDAM-002", 3, 75));


### PR DESCRIPTION
Updated maxCapacity at Location ZWOLLE-001.  
Now maxCapacity at Location is >= capacity of Warehouse at this location.

From ASSIGNMENT.md: Warehouse capacity does not exceed the maximum capacity associated with the location.